### PR TITLE
Move the link generation out of the view, to make it more reusable from Python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wagtaildraftsharing"
-version = "0.1.2"
+version = "0.1.3"
 description = "Share wagtail drafts with private URLs."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/wagtaildraftsharing/tests/test_views.py
+++ b/wagtaildraftsharing/tests/test_views.py
@@ -1,18 +1,14 @@
 import datetime
 import json
-from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.http import Http404
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
-from django.utils.timezone import is_aware
 from django.utils.timezone import now as timezone_now
-from freezegun import freeze_time
 from wagtail_factories import PageFactory
 
-import wagtaildraftsharing.views
 from wagtaildraftsharing.models import WagtaildraftsharingLink
 from wagtaildraftsharing.views import CreateSharingLinkView, SharingLinkView
 
@@ -106,37 +102,6 @@ class CreateSharingLinkViewTests(TestCase):
             "Sorry, you do not have permission to access this area",
         )
         self.assertEqual(WagtaildraftsharingLink.objects.count(), 0)
-
-    @freeze_time(FROZEN_TIME_ISOFORMATTED)
-    def test_create_sharing_link_view__max_age_from_settings(self):
-        frozen_time = datetime.datetime.fromisoformat(FROZEN_TIME_ISOFORMATTED)
-
-        # Ensure we've got a level playing field: that the time is TZ-aware
-        if not is_aware(frozen_time):
-            self.fail("frozen_time was a naive datetime but it should not be")
-
-        max_ages_and_expected_expiries = (
-            (300, frozen_time + datetime.timedelta(seconds=300)),
-            (1250000, frozen_time + datetime.timedelta(seconds=1250000)),
-            (-1, None),
-        )
-
-        for max_age, expected_expiry in max_ages_and_expected_expiries:
-            with self.subTest(max_age=max_age, expected_expiry=expected_expiry):
-                with patch.object(wagtaildraftsharing.views, "max_age", max_age):
-                    revision = self.create_revision()
-                    request = self.factory.post("/create/", {"revision": revision.id})
-                    request.user = self.superuser
-
-                    response = CreateSharingLinkView.as_view()(request)
-                    self.assertEqual(response.status_code, 200)
-
-                    link = WagtaildraftsharingLink.objects.last()
-
-                    assert link.active_until == expected_expiry, (
-                        link.active_until,
-                        expected_expiry,
-                    )
 
 
 class SharingLinkViewTests(TestCase):

--- a/wagtaildraftsharing/utils.py
+++ b/wagtaildraftsharing/utils.py
@@ -1,0 +1,13 @@
+from datetime import timezone
+
+from django.utils.timezone import is_aware, make_aware
+from django.utils.timezone import now as timezone_now
+
+
+def tz_aware_utc_now():
+    now = timezone_now()
+    # Depending on your version of Django and/or setting.TZ_NOW, timezone_now()
+    # may not actually be TZ aware, but we always want it to be for these links
+    if not is_aware(now):
+        now = make_aware(now, timezone.utc)
+    return now

--- a/wagtaildraftsharing/views.py
+++ b/wagtaildraftsharing/views.py
@@ -1,39 +1,20 @@
-import uuid
-from datetime import timezone
-
 from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
-from django.utils.timezone import is_aware, make_aware, timedelta
-from django.utils.timezone import now as timezone_now
 from django.views.generic import CreateView
 from wagtail.admin.auth import user_has_any_page_permission, user_passes_test
 from wagtail.admin.views.generic.preview import PreviewRevision
-from wagtail.log_actions import log
 from wagtail.models import Page, Revision
 
-from wagtaildraftsharing.actions import WAGTAILDRAFTSHARING_CREATE_SHARING_LINK
 from wagtaildraftsharing.forms import CreateWagtaildraftsharingLinkForm
 from wagtaildraftsharing.models import WagtaildraftsharingLink
-
-from . import settings as draftsharing_settings
-
-max_age = draftsharing_settings.WAGTAILDRAFTSHARING_MAX_AGE
-
-
-def _tz_aware_utc_now():
-    now = timezone_now()
-    # Depending on your version of Django and/or setting.TZ_NOW, timezone_now()
-    # may not actually be TZ aware, but we always want it to be for these links
-    if not is_aware(now):
-        now = make_aware(now, timezone.utc)
-    return now
+from wagtaildraftsharing.utils import tz_aware_utc_now
 
 
 class SharingLinkView(PreviewRevision):
     def setup(self, request, *args, **kwargs):
         key = kwargs.pop("key")
-        now = _tz_aware_utc_now()
+        now = tz_aware_utc_now()
 
         sharing_link = get_object_or_404(
             WagtaildraftsharingLink,
@@ -59,28 +40,10 @@ class CreateSharingLinkView(CreateView):
     form_class = CreateWagtaildraftsharingLinkForm
 
     def form_valid(self, form):
-        revision = form.cleaned_data["revision"]
-        key = uuid.uuid4()
-        if max_age > 0:
-            active_until = _tz_aware_utc_now() + timedelta(seconds=max_age)
-        else:
-            active_until = None
-        sharing_link, created = WagtaildraftsharingLink.objects.get_or_create(
-            revision=revision,
-            defaults={
-                "key": key,
-                "created_by": self.request.user,
-                "active_until": active_until,
-            },
+        sharing_link = WagtaildraftsharingLink.objects.get_or_create_for_revision(
+            revision=form.cleaned_data["revision"],
+            user=self.request.user,
         )
-        if created:
-            log(
-                instance=revision.content_object,
-                action=WAGTAILDRAFTSHARING_CREATE_SHARING_LINK,
-                user=self.request.user,
-                revision=revision,
-                data={"revision": revision.id},
-            )
         return JsonResponse({"url": sharing_link.url})
 
     def form_invalid(self, form):


### PR DESCRIPTION
Ahead of some other work we are doing, we need to programatically generate a draftsharing link.

This changeset refactors the link-generation code out of the view and into a custom Manager, giving us a way to trigger it outside of the request-response cycle.
